### PR TITLE
LCAM-1070| added enum for static table RepOrderStatuses

### DIFF
--- a/crime-validation/src/main/java/uk/gov/justice/laa/crime/validation/staticdata/enums/RepOrderStatus.java
+++ b/crime-validation/src/main/java/uk/gov/justice/laa/crime/validation/staticdata/enums/RepOrderStatus.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.laa.crime.validation.staticdata.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.stream.Stream;
+
+@Getter
+@AllArgsConstructor
+public enum RepOrderStatus {
+
+    CURR("CURR", "Current", false, true, 1),
+    FI("FI", "Awaiting FI", false, true, 2),
+    ERR("ERR", "Created in Error", true, false, 3),
+    SUSP("SUSP", "Suspended", false, true, 4),
+    NOT_SENT_FOR_TRIAL("NOT SENT FOR TRIAL", "Not sent for trial", false, true, 5);
+
+    private final String code;
+    private final String description;
+    private final boolean removeContribs;
+    private final boolean updateAllowed;
+    private final int sequence;
+
+    public static RepOrderStatus getFrom(String code) {
+        if (StringUtils.isBlank(code)) return null;
+
+        return Stream.of(RepOrderStatus.values())
+                .filter(repOrderStatus -> repOrderStatus.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Rep Order Status with value: %s does not exist.", code)));
+    }
+}

--- a/crime-validation/src/test/java/uk/gov/justice/laa/crime/validation/staticdata/enums/RepOrderStatusTest.java
+++ b/crime-validation/src/test/java/uk/gov/justice/laa/crime/validation/staticdata/enums/RepOrderStatusTest.java
@@ -22,4 +22,13 @@ class RepOrderStatusTest {
         assertThatThrownBy(() -> RepOrderStatus.getFrom("INVALID_CODE"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void givenAValidRepOrderStatus_validateEnumValues() {
+        assertThat("ERR").isEqualTo(RepOrderStatus.ERR.getCode());
+        assertThat("Created in Error").isEqualTo(RepOrderStatus.ERR.getDescription());
+        assertThat(3).isEqualTo(RepOrderStatus.ERR.getSequence());
+        assertThat(RepOrderStatus.ERR.isRemoveContribs()).isTrue();
+        assertThat(RepOrderStatus.ERR.isUpdateAllowed()).isFalse();
+    }
 }

--- a/crime-validation/src/test/java/uk/gov/justice/laa/crime/validation/staticdata/enums/RepOrderStatusTest.java
+++ b/crime-validation/src/test/java/uk/gov/justice/laa/crime/validation/staticdata/enums/RepOrderStatusTest.java
@@ -1,0 +1,25 @@
+package uk.gov.justice.laa.crime.validation.staticdata.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class RepOrderStatusTest {
+
+    @Test
+    void givenAValidCode_whenGetFromIsInvoked_thenCorrectRepOrderStatusIsReturned() {
+        assertThat(RepOrderStatus.getFrom("CURR")).isEqualTo(RepOrderStatus.CURR);
+    }
+
+    @Test
+    void givenABlankString_whenGetFromIsInvoked_thenNullIsReturned() {
+        assertThat(RepOrderStatus.getFrom(null)).isNull();
+    }
+
+    @Test
+    void givenAnInvalidCode_whenGetFromIsInvoked_thenExceptionIsThrown() {
+        assertThatThrownBy(() -> RepOrderStatus.getFrom("INVALID_CODE"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1070)

- Added enum for static table RepOrderStatuses

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
